### PR TITLE
sub image for rect

### DIFF
--- a/renderers/ebitengine/ebitengine.go
+++ b/renderers/ebitengine/ebitengine.go
@@ -61,7 +61,6 @@ func ClayRender(screen *ebiten.Image, scaleFactor float32, renderCommands clay.R
 				}
 			} else {
 				// Workaround for vector.DrawFilledRect bug on macOS/Retina displays
-				// Use a reusable 1x1 image with DrawImage and scaling for better performance
 				rectColor := color.RGBA{
 					R: uint8(config.BackgroundColor.R),
 					G: uint8(config.BackgroundColor.G),

--- a/renderers/ebitengine/ebitengine.go
+++ b/renderers/ebitengine/ebitengine.go
@@ -55,18 +55,20 @@ func ClayRender(screen *ebiten.Image, scaleFactor float32, renderCommands clay.R
 					return err
 				}
 			} else {
-				vector.DrawFilledRect(
-					screen,
-					boundingBox.X,
-					boundingBox.Y,
-					boundingBox.Width, boundingBox.Height,
-					color.RGBA{
-						R: uint8(config.BackgroundColor.R),
-						G: uint8(config.BackgroundColor.G),
-						B: uint8(config.BackgroundColor.B),
-						A: uint8(config.BackgroundColor.A),
-					}, true,
+				// Workaround for vector.DrawFilledRect bug on macOS/Retina displays
+				// Use a sub-image and fill it instead
+				rect := image.Rect(
+					int(boundingBox.X), int(boundingBox.Y),
+					int(boundingBox.X+boundingBox.Width),
+					int(boundingBox.Y+boundingBox.Height),
 				)
+				subImg := screen.SubImage(rect).(*ebiten.Image)
+				subImg.Fill(color.RGBA{
+					R: uint8(config.BackgroundColor.R),
+					G: uint8(config.BackgroundColor.G),
+					B: uint8(config.BackgroundColor.B),
+					A: uint8(config.BackgroundColor.A),
+				})
 			}
 		case clay.RENDER_COMMAND_TYPE_TEXT:
 			config := &renderCommand.RenderData.Text


### PR DESCRIPTION
I am on MacBook Pro M4 Max with macOS 26.

Here is a simple example where I tried to render one big red rectangle.

I saw these rendering artifacts:

<img width="1512" height="982" alt="Screenshot 2025-11-21 at 00 30 08" src="https://github.com/user-attachments/assets/8b4de45b-6dbb-42a4-8223-137c665573b4" />

after the change:

<img width="1512" height="982" alt="Screenshot 2025-11-21 at 00 31 33" src="https://github.com/user-attachments/assets/0e00508e-9400-4ddd-bce5-03a3c7405204" />
